### PR TITLE
refac: cleanup onboarding copy and oauth button size

### DIFF
--- a/components/onboarding/oauth-connection-page/oauth-connection-page.scss.js
+++ b/components/onboarding/oauth-connection-page/oauth-connection-page.scss.js
@@ -12,6 +12,7 @@ export default scss`
   
   box-sizing: border-box;
   padding: 48px 32px;
+  
 
   > .info {
     @include flex-column;
@@ -21,8 +22,12 @@ export default scss`
     text-align: center;
     font-size: 16px;
     margin-top: 40px;
-    font-weight: bold;
     color: var(--mm-color-text-bg-primary);
+
+    > .title {
+      font-size: 20px;
+      font-weight: bold;
+    }
   }
 
   .oauth-button {
@@ -30,7 +35,7 @@ export default scss`
     align-items: center;
     max-width: 308px;
     box-sizing: border-box;
-    margin: 20px auto;
+    margin: 20px auto 8px auto;
     padding: 12px, 20px, 12px, 20px;
     height: 42px;
     gap: 8px;

--- a/components/onboarding/oauth-connection-page/oauth-connection-page.tsx
+++ b/components/onboarding/oauth-connection-page/oauth-connection-page.tsx
@@ -31,8 +31,11 @@ export default function OAuthConnectionPage(
           height={300}
         />
         <div className="info">
-          Connect your YouTube account to share your name and channel ID to start earning channel
-          points, unlocking rewards, and participating in polls and predictions through Truffle.
+          <div className="title">
+            Let's get started
+          </div>
+          Connect your Youtube account to start earning channel points, unlocking rewards, and
+          participating in polls and predictions through Truffle
         </div>
         <OAuthButton sourceType={sourceType} />
         <a
@@ -85,9 +88,9 @@ function OAuthButton(
       accessToken={accessToken}
       orgId={orgId}
       styles={{
-        width: "148px",
+        width: "236px",
         height: "42px",
-        margin: "20px auto",
+        margin: "20px auto 8px auto",
         border: "none",
       }}
     />

--- a/truffle.config.mjs
+++ b/truffle.config.mjs
@@ -1,6 +1,6 @@
 export default {
   name: "@truffle/mogul-menu",
-  version: "0.1.89",
+  version: "0.1.90",
   // name: "@truffle-dev-early-access/mogul-menu",
   // version: "0.5.6",
   // staging


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24517783/190005518-24de79ec-659c-4ced-a702-177d08a96d13.png)

updated the oauth button sizing and onboarding copy