### PR TITLE
feat: fcm token manager/notification delivery

### DIFF
--- a/components/test-tab/test-tab.tsx
+++ b/components/test-tab/test-tab.tsx
@@ -1,4 +1,4 @@
-import { React, useState } from "../../deps.ts";
+import { React, useState, useEffect } from "../../deps.ts";
 import { useCurrentTab, useTabButton, useTabSlug } from "../tabs/mod.ts";
 import { getMenuPosition, useMenu } from "../menu/mod.ts";
 import { useSnackBar } from "../snackbar/mod.ts";
@@ -17,6 +17,7 @@ import { useDialog } from "../base/dialog-container/dialog-service.ts";
 import DefaultDialogContentFragment from "../dialogs/content-fragments/default/default-dialog-content-fragment.tsx";
 import Switch from "../base/switch/switch.tsx";
 import { Page } from "../page-stack/mod.ts";
+import { useFcmTokenManager } from "../../shared/util/firebase/fcm.ts";
 
 const TAB_BAR_BUTTON = "tab-bar-button";
 
@@ -40,7 +41,7 @@ export default function TestTab() {
   const [selectedValue, setSelectedValue] = useState();
   const { state: menuState, updateMenuPosition } = useMenu();
   const [menuPositionValue, setMenuPositionValue] = useState(
-    getMenuPosition(menuState),
+    getMenuPosition(menuState)
   );
   const additionalData = { value: selectedValue };
 
@@ -56,7 +57,7 @@ export default function TestTab() {
   const snackBarHandler = () => {
     console.log("enqueueing snackbar");
     enqueueSnackBar(
-      <SnackBar message={`Congrats! You won. ${count}`} value="1000 cp" />,
+      <SnackBar message={`Congrats! You won. ${count}`} value="1000 cp" />
     );
     setCount((prev) => prev + 1);
     setSelected((prev) => !prev);
@@ -76,10 +77,12 @@ export default function TestTab() {
   const actionBannerHandler = () => {
     const actionBannerId = displayActionBanner(
       <ActionBanner
-        action={<Button onClick={() => removeActionBanner(actionBannerId)}></Button>}
+        action={
+          <Button onClick={() => removeActionBanner(actionBannerId)}></Button>
+        }
       >
         Finish setting up your account
-      </ActionBanner>,
+      </ActionBanner>
     );
   };
 
@@ -97,7 +100,7 @@ export default function TestTab() {
           primaryText="Hello"
           secondaryText="How are you?"
         />
-      </Dialog>,
+      </Dialog>
     );
   };
 
@@ -109,6 +112,11 @@ export default function TestTab() {
       <Button onClick={removeButtonHandler}>Remove button</Button>
     );
   };
+
+  const { requestNotificationPermission, fcmToken } = useFcmTokenManager();
+  useEffect(() => {
+    console.log("[mm] new fcm token", fcmToken);
+  }, [fcmToken]);
 
   return (
     <div className="z-home-tab">
@@ -124,6 +132,9 @@ export default function TestTab() {
         <Button onClick={actionBannerHandler}>Show action banner</Button>
         <Button onClick={toggleDialogHandler}>Show dialog</Button>
         <Button onClick={addButtonHandler}>Add tab bar button</Button>
+        <Button onClick={requestNotificationPermission}>
+          Request notification perms
+        </Button>
       </div>
       <div>
         <Switch value={true} />

--- a/deps.ts
+++ b/deps.ts
@@ -77,3 +77,12 @@ export {
   useHandleTruffleOAuth,
 } from "https://tfl.dev/@truffle/third-party-oauth@^0.0.20/components/oauth-iframe/mod.ts";
 export type { OAuthResponse } from "https://tfl.dev/@truffle/third-party-oauth@^0.0.20/components/oauth-iframe/mod.ts";
+
+export {
+  getApp as getFirebaseApp,
+  initializeApp as initializeFirebaseApp,
+} from "https://npm.tfl.dev/firebase@9.9.4/app";
+export {
+  getMessaging as getFCMMessaging,
+  getToken as getFCMToken,
+} from "https://npm.tfl.dev/firebase@9.9.4/messaging";

--- a/shared/util/firebase/app.ts
+++ b/shared/util/firebase/app.ts
@@ -1,0 +1,21 @@
+import { TRUFFLE_FIREBASE_CONFIG } from "./config.js";
+import { getFirebaseApp, initializeFirebaseApp, useEffect, useState } from "../../../deps.ts";
+
+export function useFirebase() {
+  const [firebaseApp, setFirebaseApp] = useState();
+
+  // set the firebase app on load
+  useEffect(() => {
+    try {
+      // try to get the existing app if it has already been initialized
+      const existingApp = getFirebaseApp();
+      setFirebaseApp(existingApp);
+    } catch {
+      // if the app hasn't been initialized, initialize it
+      const app = initializeFirebaseApp(TRUFFLE_FIREBASE_CONFIG);
+      setFirebaseApp(app);
+    }
+  }, []);
+
+  return { firebaseApp };
+}

--- a/shared/util/firebase/config.js
+++ b/shared/util/firebase/config.js
@@ -1,0 +1,11 @@
+export const TRUFFLE_FIREBASE_CONFIG = {
+  apiKey: "AIzaSyCrlknC6fL012iV8vvX1jUcIFPfDJzBOJk",
+  authDomain: "spore-gg.firebaseapp.com",
+  projectId: "spore-gg",
+  storageBucket: "spore-gg.appspot.com",
+  messagingSenderId: "277610744288",
+  appId: "1:277610744288:web:fbb43fc374b6f8ce5ac385",
+  measurementId: "G-3QC8231033",
+  vapidKey:
+    "BIT0bxDZp5dHoHfNU_oCeUmOOY6qPNpsY2Y1PfcQviPaD0INH5T9_6Qr44lEGc0bpNRpa7Z8lXnKFP9AtL3v7NM",
+};

--- a/shared/util/firebase/fcm.ts
+++ b/shared/util/firebase/fcm.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "../../../deps.ts";
+import { useServiceWorker } from "../mod.ts";
+import { getFCMMessaging, getFCMToken } from "../../../deps.ts";
+import { TRUFFLE_FIREBASE_CONFIG } from "./config.js";
+import { useFirebase } from "./app.ts";
+
+export function useFcmTokenManager() {
+  const { swRegistration } = useServiceWorker();
+  const [fcmToken, setFcmToken] = useState();
+  const [notificationPermission, setNotificationPermission] = useState(() =>
+    Notification.permission
+  );
+  const { firebaseApp } = useFirebase();
+
+  const requestNotificationPermission = async () => {
+    // make sure we have browser-level notification perms
+    const permission = await Notification.requestPermission();
+    setNotificationPermission(permission);
+  };
+
+  // listen to the notification permission state and get an
+  // fcm token if the user granted notification permissions
+  useEffect(() => {
+    if (notificationPermission === "granted" && firebaseApp) {
+      const messaging = getFCMMessaging(firebaseApp);
+      getFCMToken(messaging, {
+        vapidKey: TRUFFLE_FIREBASE_CONFIG.vapidKey,
+        serviceWorkerRegistration: swRegistration,
+      }).then((token: string) => {
+        setFcmToken(token);
+      });
+    }
+  }, [notificationPermission, firebaseApp]);
+
+  return { requestNotificationPermission, notificationPermission, fcmToken };
+}

--- a/shared/util/mod.ts
+++ b/shared/util/mod.ts
@@ -6,6 +6,7 @@ export * from "./season-pass/mod.ts";
 export * from "./invalidate/mod.ts";
 export * from "./icon/mod.ts";
 export * from "./general.ts";
-export * from './extension-auth/mod.ts'
-export * from './jumper/mod.ts'
-export * from './org-user/mod.ts'
+export * from "./extension-auth/mod.ts";
+export * from "./jumper/mod.ts";
+export * from "./org-user/mod.ts";
+export * from "./service-worker/mod.ts";

--- a/shared/util/service-worker/hooks.ts
+++ b/shared/util/service-worker/hooks.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "../../../deps.ts";
+
+const SERVICE_WORKER_PATH = "/shared/util/service-worker/service-worker.js";
+
+export function useServiceWorker() {
+  const [swRegistration, setSwRegistration] = useState();
+
+  useEffect(() => {
+    // make sure the current env supports service workers
+    if ("serviceWorker" in navigator) {
+      // check if we've already registered a service worker for this domain
+      navigator.serviceWorker.getRegistration(SERVICE_WORKER_PATH).then((registration) => {
+        // if we found a registration, set it as the current registration
+        if (registration) {
+          setSwRegistration(registration);
+
+          // otherwise, register our service worker
+        } else {
+          navigator.serviceWorker.register(SERVICE_WORKER_PATH, { type: "module" }).then(
+            (registration) => {
+              setSwRegistration(registration);
+
+              if (registration.installing) {
+                console.log("[mm] Service worker installing");
+              } else if (registration.waiting) {
+                console.log("[mm] Service worker installed");
+              } else if (registration.active) {
+                console.log("[mm] Service worker active");
+              }
+            },
+          ).catch((error) => {
+            console.error(`[mm] Registration failed with ${error}`);
+          });
+        }
+      });
+    }
+  }, []);
+
+  return { swRegistration };
+}

--- a/shared/util/service-worker/mod.ts
+++ b/shared/util/service-worker/mod.ts
@@ -1,0 +1,1 @@
+export * from "./hooks.ts";

--- a/shared/util/service-worker/service-worker.js
+++ b/shared/util/service-worker/service-worker.js
@@ -1,0 +1,19 @@
+/**
+ * We use this service worker to deliver push notifications to users
+ * while they are not viewing a stream.
+ */
+
+import { TRUFFLE_FIREBASE_CONFIG } from "../firebase/config.js";
+import { initializeApp } from "https://npm.tfl.dev/firebase@9.9.4/app";
+import { getMessaging } from "https://npm.tfl.dev/firebase@9.9.4/messaging/sw";
+
+initializeApp(TRUFFLE_FIREBASE_CONFIG);
+
+// Retrieve an instance of Firebase Messaging so that it can handle background
+// messages. This will generate a notification to display to the user if
+// it receives a message while in the background.
+getMessaging();
+
+self.addEventListener("install", () => {
+  console.log("Mogul menu service worker installed");
+});


### PR DESCRIPTION
This PR:
- Adds firebase to mogul-menu
- Adds a service worker which delivers FCM notifications to users
- Exposes `useFcmTokenManager` to handle requesting browser-level notification perms and retrieval of an FCM token
  - The FCM token is meant to be stored in a NotificationMediumUserConfig in mycelium, coming in a future PR